### PR TITLE
Remove leading dot from result suffix

### DIFF
--- a/design.md
+++ b/design.md
@@ -49,7 +49,7 @@ interface DomainSearchResult {
 
 interface DomainItem {
   domain: string;          // Full domain (e.g. "foobar.com")
-  suffix: string;          // The TLD suffix (e.g. ".com" or ".com.ng")
+  suffix: string;          // The TLD suffix (e.g. "com" or "com.ng")
   score: number;           // Internal score used for ranking (not exposed by default)
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ Search for domain names based on a query string.
 | Field | Type | Description |
 | --- | --- | --- |
 | `domain` | `string` | Fully qualified domain name. |
-| `suffix` | `string` | TLD including the leading dot. |
+| `suffix` | `string` | TLD without the leading dot. |
 | `score` | `number` | Relative ranking score for the domain. |
 | `isAvailable` | `boolean?` | Domain availability flag (only with `debug`). |
 | `aiGenerated` | `boolean?` | Marks names produced by AI. |

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ export class DomainSearchClient {
           const score = scoreDomain(parts.join('.'), suffix, cc, {
             tldWeights: this.config.tldWeights,
           });
-          results.push({ domain, suffix: '.' + suffix, score, isAvailable: false, variantTypes: types });
+          results.push({ domain, suffix, score, isAvailable: false, variantTypes: types });
         }
         continue;
       }
@@ -114,7 +114,7 @@ export class DomainSearchClient {
         if (supportedTlds && !supportedTlds.includes(tld)) continue;
         const domain = `${label}.${tld}`;
         const score = scoreDomain(label, tld, cc, { tldWeights: this.config.tldWeights });
-        results.push({ domain, suffix: '.' + tld, score, isAvailable: false, variantTypes: types });
+        results.push({ domain, suffix: tld, score, isAvailable: false, variantTypes: types });
       }
     }
 

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -47,7 +47,7 @@ test('AI flag populates includesAiGenerations', async t => {
 
 test('supportedTlds filter applies and is noted in metadata', async t => {
   const res = await client.search({ query: 'fast tech', supportedTlds: ['net'] });
-  t.true(res.results.every(r => r.suffix === '.net'));
+  t.true(res.results.every(r => r.suffix === 'net'));
   t.true(res.metadata.filterApplied);
 });
 


### PR DESCRIPTION
## Summary
- return suffix values without a leading dot in domain search results
- adjust tests and documentation for new suffix format

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b00a7222e08326a60823d656f8f2ff