### PR TITLE
refactor: split init and search options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,34 +23,50 @@ console.log(results.results);
 
 ## API
 
-### `client.search(params)`
+### `new DomainSearchClient(initOptions?)`
 
-Search for domain names based on a query string.
+Create a client with default search configuration.
 
-#### Parameters
+#### Init Options
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `supportedTlds` | `string[]` | all known TLDs | TLDs allowed in results. |
+| `defaultTlds` | `string[]` | `['com','ng']` | TLDs always included when generating names. |
+| `limit` | `number` | `20` | Maximum number of domains returned. |
+| `prefixes` | `string[]` | – | Prefixes used for generating variants. |
+| `suffixes` | `string[]` | – | Suffixes used for generating variants. |
+| `maxSynonyms` | `number` | `5` | Maximum number of synonyms to expand. |
+| `tldWeights` | `Record<string, number>` | – | Weights used when ranking TLDs. |
+
+### `client.search(options)`
+
+Search for domain names. `options` extend the init options so each call can override them.
+
+#### Search Options
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `query` | `string` | – | Search term to expand. |
 | `keywords` | `string[]` | – | Additional keywords to combine with the query. |
 | `location` | `string` | – | ISO country code used to include a ccTLD. |
-| `supportedTlds` | `string[]` | `['com','net','org']` | TLDs allowed in results. |
-| `defaultTlds` | `string[]` | `['com']` | TLDs always included when generating names. |
-| `limit` | `number` | `20` | Maximum number of domains returned. |
 | `debug` | `boolean` | `false` | When `true`, includes extra debug fields. |
 | `useAi` | `boolean` | `false` | Expand ideas using AI generation. |
+| `supportedTlds` | `string[]` | inherits from init | TLDs allowed in results. |
+| `defaultTlds` | `string[]` | inherits from init | TLDs always included when generating names. |
+| `limit` | `number` | inherits from init | Maximum number of domains returned. |
 
 #### Response
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `results` | `DomainResult[]` | List of generated domains ordered by score. |
+| `results` | `DomainCandidate[]` | List of generated domains ordered by score. |
 | `success` | `boolean` | Indicates whether the search completed successfully. |
 | `message` | `string?` | Error message when `success` is `false`. |
 | `includesAiGenerations` | `boolean` | Whether AI-generated names were requested. |
 | `metadata` | `object` | Runtime details about the search (see below). |
 
-**DomainResult**
+**DomainCandidate**
 
 | Field | Type | Description |
 | --- | --- | --- |

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { DomainSearchParams, DomainResult, SearchResponse, DomainSearchConfig } from './types';
+import { DomainSearchOptions, DomainCandidate, SearchResponse, ClientInitOptions } from './types';
 import { normalizeTokens, unique, isValidTld, getCcTld, normalizeTld } from './utils';
 import { generateLabels } from './generator';
 import { scoreDomain } from './ranking';
@@ -11,7 +11,7 @@ const TLD_MAP: Record<string, string | boolean> = {
   ...(tlds as any).SLDs,
 };
 
-const DEFAULT_CONFIG: DomainSearchConfig = {
+const DEFAULT_INIT_OPTIONS: Required<ClientInitOptions> = {
   defaultTlds: ['com', 'ng'],
   supportedTlds: Object.keys(TLD_MAP),
   limit: 20,
@@ -50,52 +50,53 @@ function error(message: string): SearchResponse {
 }
 
 export class DomainSearchClient {
-  private config: DomainSearchConfig;
+  private init: Required<ClientInitOptions>;
 
-  constructor(config: Partial<DomainSearchConfig> = {}) {
-    this.config = { ...DEFAULT_CONFIG, ...config };
+  constructor(initOptions: ClientInitOptions = {}) {
+    this.init = { ...DEFAULT_INIT_OPTIONS, ...initOptions };
   }
 
-  setConfig(config: Partial<DomainSearchConfig>): void {
-    this.config = { ...this.config, ...config };
+  setInitOptions(options: ClientInitOptions): void {
+    this.init = { ...this.init, ...options };
   }
 
-  getConfig(): DomainSearchConfig {
-    return this.config;
+  getInitOptions(): Required<ClientInitOptions> {
+    return this.init;
   }
 
-  async search(params: DomainSearchParams): Promise<SearchResponse> {
+  async search(options: DomainSearchOptions): Promise<SearchResponse> {
     const start = Date.now();
-    if (!params.query || !params.query.trim()) return error('query is required');
+    if (!options.query || !options.query.trim()) return error('query is required');
 
-    const limit = params.limit ?? this.config.limit;
+    const cfg = { ...this.init, ...options };
+    const limit = cfg.limit ?? this.init.limit;
     if (!Number.isFinite(limit) || limit <= 0) return error('limit must be positive');
 
-    if (params.keywords && !Array.isArray(params.keywords)) return error('keywords must be an array');
-    if (params.supportedTlds && !Array.isArray(params.supportedTlds)) return error('supportedTlds must be an array');
-    if (params.defaultTlds && !Array.isArray(params.defaultTlds)) return error('defaultTlds must be an array');
+    if (options.keywords && !Array.isArray(options.keywords)) return error('keywords must be an array');
+    if (options.supportedTlds && !Array.isArray(options.supportedTlds)) return error('supportedTlds must be an array');
+    if (options.defaultTlds && !Array.isArray(options.defaultTlds)) return error('defaultTlds must be an array');
 
-    const supportedTlds = (params.supportedTlds ?? this.config.supportedTlds).map(normalizeTld);
-    const defaultTlds = (params.defaultTlds ?? this.config.defaultTlds).map(normalizeTld);
+    const supportedTlds = (cfg.supportedTlds || []).map(normalizeTld);
+    const defaultTlds = (cfg.defaultTlds || []).map(normalizeTld);
     for (const t of [...supportedTlds, ...defaultTlds]) {
       if (!isValidTld(t)) return error(`invalid tld: ${t}`);
     }
 
-    const tokens = normalizeTokens(params.query);
-    const keywords = params.keywords?.map(k => k.toLowerCase()) || [];
+    const tokens = normalizeTokens(options.query);
+    const keywords = options.keywords?.map(k => k.toLowerCase()) || [];
     const tldsForGen = unique([...supportedTlds, ...defaultTlds]);
     const labels = generateLabels(tokens, keywords, tldsForGen, {
-      prefixes: this.config.prefixes,
-      suffixes: this.config.suffixes,
-      maxSynonyms: this.config.maxSynonyms,
+      prefixes: cfg.prefixes,
+      suffixes: cfg.suffixes,
+      maxSynonyms: cfg.maxSynonyms,
     });
 
     let tlds = tldsForGen.slice();
-    const cc = getCcTld(params.location);
+    const cc = getCcTld(options.location);
     if (cc && !tlds.includes(cc)) tlds.push(cc);
     if (cc && !supportedTlds.includes(cc)) supportedTlds.push(cc);
 
-    const results: DomainResult[] = [];
+    const results: DomainCandidate[] = [];
     for (const { label, types } of labels) {
       if (label.length === 0) continue;
       if (label.includes('.')) {
@@ -104,7 +105,7 @@ export class DomainSearchClient {
         if (supportedTlds.includes(suffix)) {
           const domain = label;
           const score = scoreDomain(parts.join('.'), suffix, cc, {
-            tldWeights: this.config.tldWeights,
+            tldWeights: cfg.tldWeights,
           });
           results.push({ domain, suffix, score, isAvailable: false, variantTypes: types });
         }
@@ -113,12 +114,12 @@ export class DomainSearchClient {
       for (const tld of tlds) {
         if (supportedTlds && !supportedTlds.includes(tld)) continue;
         const domain = `${label}.${tld}`;
-        const score = scoreDomain(label, tld, cc, { tldWeights: this.config.tldWeights });
+        const score = scoreDomain(label, tld, cc, { tldWeights: cfg.tldWeights });
         results.push({ domain, suffix: tld, score, isAvailable: false, variantTypes: types });
       }
     }
 
-    const resultMap = new Map<string, DomainResult>();
+    const resultMap = new Map<string, DomainCandidate>();
     for (const r of results) {
       const existing = resultMap.get(r.domain);
       if (existing) {
@@ -134,7 +135,7 @@ export class DomainSearchClient {
     uniqueResults.sort((a, b) => b.score - a.score);
 
     let finalResults = uniqueResults.slice(0, limit);
-    if (!params.debug) {
+    if (!options.debug) {
       finalResults = finalResults.map(r => ({ domain: r.domain, suffix: r.suffix, score: r.score }));
     }
 
@@ -142,15 +143,15 @@ export class DomainSearchClient {
     return {
       results: finalResults,
       success: true,
-      includesAiGenerations: !!params.useAi,
+      includesAiGenerations: !!options.useAi,
       metadata: {
         searchTime: end - start,
         totalGenerated: uniqueResults.length,
-        filterApplied: !!params.supportedTlds,
+        filterApplied: !!options.supportedTlds,
       },
     };
   }
 }
 
-export type { DomainSearchParams, DomainResult, SearchResponse } from './types';
+export type { DomainSearchOptions, ClientInitOptions, DomainCandidate, SearchResponse } from './types';
 export { generateLabels } from './generator';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,15 +1,22 @@
-export interface DomainSearchParams {
+export interface ClientInitOptions {
+  defaultTlds?: string[];
+  supportedTlds?: string[];
+  limit?: number;
+  prefixes?: string[];
+  suffixes?: string[];
+  maxSynonyms?: number;
+  tldWeights?: Record<string, number>;
+}
+
+export interface DomainSearchOptions extends ClientInitOptions {
   query: string;
   keywords?: string[];
   location?: string;
-  supportedTlds?: string[];
-  defaultTlds?: string[];
-  limit?: number;
   debug?: boolean;
   useAi?: boolean;
 }
 
-export interface DomainResult {
+export interface DomainCandidate {
   domain: string;
   suffix: string;
   score: number;
@@ -19,7 +26,7 @@ export interface DomainResult {
 }
 
 export interface SearchResponse {
-  results: DomainResult[];
+  results: DomainCandidate[];
   success: boolean;
   message?: string;
   includesAiGenerations: boolean;
@@ -30,12 +37,3 @@ export interface SearchResponse {
   };
 }
 
-export interface DomainSearchConfig {
-  defaultTlds: string[];
-  supportedTlds: string[];
-  limit: number;
-  prefixes?: string[];
-  suffixes?: string[];
-  maxSynonyms?: number;
-  tldWeights?: Record<string, number>;
-}


### PR DESCRIPTION
## Summary
- introduce separate `ClientInitOptions` and `DomainSearchOptions`
- allow per-search overrides of client initialization settings
- document init vs. search options and rename init options interface to `ClientInitOptions`
- rename `DomainResult` to `DomainCandidate`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b85e3a44ec8326a06f92d2d6fd9a74