### PR TITLE
refactor: modular generation strategies

### DIFF
--- a/impl.md
+++ b/impl.md
@@ -64,6 +64,8 @@ Parses and normalizes search queries, extracts meaningful tokens.
 #### 2.2.4 Domain Generator Engine
 Creates domain name variations based on processed queries.
 
+The generator is composed of independent strategies located in `src/strategies`. Each strategy implements a common interface and executes in parallel, returning domain candidates tagged with the strategy that produced them.
+
 #### 2.2.5 Ranking Engine
 Scores and sorts generated domains based on relevance factors.
 
@@ -75,17 +77,25 @@ Manages supported TLDs and location-based TLD recommendations.
 ### 3.1 Main Interface
 
 ```typescript
-interface DomainSearchParams {
-  query: string;                    // Required: search term(s)
-  keywords?: string[];              // Optional: seeding keywords
-  location?: string;                // Optional: 2-char country code
-  supported_tlds?: string[];        // Optional: limit to these TLDs
-  default_tlds?: string[];          // Optional: preferred TLDs
-  limit?: number;                   // Optional: max results (default: 20)
-  includeAiGenerated?: boolean;     // Optional: include AI suggestions
+interface ClientInitOptions {
+  defaultTlds?: string[];            // Preferred TLDs
+  supportedTlds?: string[];          // Allowed TLDs
+  limit?: number;                    // Max results (default: 20)
+  prefixes?: string[];               // Prefixes for generation
+  suffixes?: string[];               // Suffixes for generation
+  maxSynonyms?: number;              // Synonym expansion limit
+  tldWeights?: Record<string, number>; // TLD ranking weights
 }
 
-interface DomainResult {
+interface DomainSearchOptions extends ClientInitOptions {
+  query: string;                     // Required: search term(s)
+  keywords?: string[];               // Optional: seeding keywords
+  location?: string;                 // Optional: 2-char country code
+  debug?: boolean;                   // Include debug info
+  useAi?: boolean;                   // Include AI suggestions
+}
+
+interface DomainCandidate {
   domain: string;                   // Full domain name
   suffix: string;                   // TLD suffix
   score?: number;                   // Relevance score (internal)
@@ -94,7 +104,7 @@ interface DomainResult {
 }
 
 interface SearchResponse {
-  results: DomainResult[];
+  results: DomainCandidate[];
   success: boolean;
   message?: string;
   includes_ai_generations: boolean;
@@ -110,27 +120,27 @@ interface SearchResponse {
 
 ```typescript
 class DomainSearchClient {
-  constructor(config?: DomainSearchConfig);
-  
-  search(params: DomainSearchParams): Promise<SearchResponse>;
-  
-  setConfig(config: Partial<DomainSearchConfig>): void;
-  getConfig(): DomainSearchConfig;
+  constructor(initOptions?: ClientInitOptions);
+
+  search(options: DomainSearchOptions): Promise<SearchResponse>;
+
+  setInitOptions(options: ClientInitOptions): void;
+  getInitOptions(): ClientInitOptions;
 }
 ```
 
 ### 3.3 Configuration Interface
 
 ```typescript
-interface DomainSearchConfig {
-  defaultLimit: number;             // Default: 20
-  defaultTlds: string[];            // Default: ['com', 'net', 'org', 'io']
-  enableAiGeneration: boolean;      // Default: false
-  maxQueryLength: number;           // Default: 100
-  minDomainLength: number;          // Default: 2
-  maxDomainLength: number;          // Default: 63
-  rankingWeights: RankingWeights;   // Scoring configuration
-  tldData: TldDatabase;            // TLD information database
+interface ClientInitOptions {
+  defaultLimit?: number;             // Default: 20
+  defaultTlds?: string[];            // Default: ['com', 'net', 'org', 'io']
+  enableAiGeneration?: boolean;      // Default: false
+  maxQueryLength?: number;           // Default: 100
+  minDomainLength?: number;          // Default: 2
+  maxDomainLength?: number;          // Default: 63
+  rankingWeights?: RankingWeights;   // Scoring configuration
+  tldData?: TldDatabase;             // TLD information database
 }
 
 interface RankingWeights {
@@ -171,7 +181,7 @@ class QueryProcessor {
 
 ```typescript
 class DomainGenerator {
-  generate(processedQuery: ProcessedQuery, params: DomainSearchParams): string[] {
+  generate(processedQuery: ProcessedQuery, params: DomainSearchOptions): string[] {
     const strategies = [
       this.exactMatchStrategy,        // foo.bar for "foo bar"
       this.concatenationStrategy,     // foobar.com for "foo bar"
@@ -199,7 +209,7 @@ class DomainGenerator {
 
 ```typescript
 class RankingEngine {
-  rank(domains: DomainResult[], params: DomainSearchParams): DomainResult[] {
+  rank(domains: DomainCandidate[], params: DomainSearchOptions): DomainCandidate[] {
     return domains
       .map(domain => ({
         ...domain,
@@ -209,7 +219,7 @@ class RankingEngine {
       .slice(0, params.limit || 20);
   }
   
-  private calculateScore(domain: DomainResult, params: DomainSearchParams): number {
+  private calculateScore(domain: DomainCandidate, params: DomainSearchOptions): number {
     let score = 0;
     const weights = this.config.rankingWeights;
     
@@ -259,7 +269,7 @@ class TldManager {
     restrictions?: string[];      // Registration restrictions
   }
   
-  getSupportedTlds(params?: DomainSearchParams): string[] {
+  getSupportedTlds(params?: DomainSearchOptions): string[] {
     // Return filtered TLDs based on parameters
   }
   

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@ A simple TypeScript library for generating and ranking domain name suggestions.
 - Expands queries with synonyms
 - Generates permutations with prefixes, suffixes, and hyphen variants
 - Filters and ranks domains based on TLD popularity and heuristics
+- Modular generation strategies execute in parallel and tag results with their source
 
 ## Installation
 ```bash
@@ -23,34 +24,50 @@ console.log(results.results);
 
 ## API
 
-### `client.search(params)`
+### `new DomainSearchClient(initOptions?)`
 
-Search for domain names based on a query string.
+Create a client with default search configuration.
 
-#### Parameters
+#### Init Options
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `supportedTlds` | `string[]` | all known TLDs | TLDs allowed in results. |
+| `defaultTlds` | `string[]` | `['com','ng']` | TLDs always included when generating names. |
+| `limit` | `number` | `20` | Maximum number of domains returned. |
+| `prefixes` | `string[]` | – | Prefixes used for generating variants. |
+| `suffixes` | `string[]` | – | Suffixes used for generating variants. |
+| `maxSynonyms` | `number` | `5` | Maximum number of synonyms to expand. |
+| `tldWeights` | `Record<string, number>` | – | Weights used when ranking TLDs. |
+
+### `client.search(options)`
+
+Search for domain names. `options` extend the init options so each call can override them.
+
+#### Search Options
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `query` | `string` | – | Search term to expand. |
 | `keywords` | `string[]` | – | Additional keywords to combine with the query. |
 | `location` | `string` | – | ISO country code used to include a ccTLD. |
-| `supportedTlds` | `string[]` | `['com','net','org']` | TLDs allowed in results. |
-| `defaultTlds` | `string[]` | `['com']` | TLDs always included when generating names. |
-| `limit` | `number` | `20` | Maximum number of domains returned. |
 | `debug` | `boolean` | `false` | When `true`, includes extra debug fields. |
 | `useAi` | `boolean` | `false` | Expand ideas using AI generation. |
+| `supportedTlds` | `string[]` | inherits from init | TLDs allowed in results. |
+| `defaultTlds` | `string[]` | inherits from init | TLDs always included when generating names. |
+| `limit` | `number` | inherits from init | Maximum number of domains returned. |
 
 #### Response
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `results` | `DomainResult[]` | List of generated domains ordered by score. |
+| `results` | `DomainCandidate[]` | List of generated domains ordered by score. |
 | `success` | `boolean` | Indicates whether the search completed successfully. |
 | `message` | `string?` | Error message when `success` is `false`. |
 | `includesAiGenerations` | `boolean` | Whether AI-generated names were requested. |
 | `metadata` | `object` | Runtime details about the search (see below). |
 
-**DomainResult**
+**DomainCandidate**
 
 | Field | Type | Description |
 | --- | --- | --- |
@@ -60,6 +77,7 @@ Search for domain names based on a query string.
 | `isAvailable` | `boolean?` | Domain availability flag (only with `debug`). |
 | `aiGenerated` | `boolean?` | Marks names produced by AI. |
 | `variantTypes` | `string[]?` | Types of permutations used (only with `debug`). |
+| `strategy` | `string?` | Strategy that generated the domain. |
 
 **Metadata**
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,117 +1,34 @@
-import { expandSynonyms } from './synonyms';
-import { unique } from './utils';
+import {
+  PermutationStrategy,
+  AlphabeticalStrategy,
+  AffixStrategy,
+  TldHackStrategy,
+  PermutationStrategyOptions,
+} from './strategies';
+import { DomainSearchOptions, DomainCandidate, GenerationStrategy } from './types';
 
-type GenConfig = {
-  prefixes?: string[];
-  suffixes?: string[];
-  maxSynonyms?: number;
-};
-
-export interface GeneratedLabel {
-  label: string;
-  types: string[];
+export interface GenConfig {
+  strategyOptions?: {
+    permutation?: PermutationStrategyOptions;
+  };
 }
 
-function combine(lists: string[][], joiner = ''): string[] {
-  const results: string[] = [];
-  function helper(prefix: string, idx: number) {
-    if (idx === lists.length) {
-      results.push(prefix);
-      return;
-    }
-    for (const token of lists[idx]) {
-      const next = prefix ? prefix + joiner + token : token;
-      helper(next, idx + 1);
-    }
-  }
-  if (lists.length) helper('', 0);
-  return results;
-}
+export async function generateCandidates(
+  options: DomainSearchOptions,
+  config: GenConfig = {},
+): Promise<Partial<DomainCandidate & { strategy: string }>[]> {
+  const strategies: { name: string; strategy: GenerationStrategy }[] = [
+    { name: 'permutation', strategy: new PermutationStrategy(config.strategyOptions?.permutation) },
+    { name: 'alphabetical', strategy: new AlphabeticalStrategy() },
+    { name: 'affix', strategy: new AffixStrategy() },
+    { name: 'tldHack', strategy: new TldHackStrategy() },
+  ];
 
-function permute<T>(arr: T[]): T[][] {
-  if (arr.length <= 1) return [arr];
-  const result: T[][] = [];
-  arr.forEach((item, idx) => {
-    const rest = [...arr.slice(0, idx), ...arr.slice(idx + 1)];
-    for (const p of permute(rest)) {
-      result.push([item, ...p]);
-    }
+  const results = await Promise.all(strategies.map(s => s.strategy.generate(options)));
+  const combined: Partial<DomainCandidate & { strategy: string }>[] = [];
+  results.forEach((arr, idx) => {
+    const name = strategies[idx].name;
+    arr.forEach(c => combined.push({ ...c, strategy: name }));
   });
-  return result;
-}
-
-export function generateLabels(
-  tokens: string[],
-  keywords: string[] = [],
-  tlds: string[] = [],
-  config: GenConfig = {}
-): GeneratedLabel[] {
-  const maxSyn = config.maxSynonyms ?? 5;
-  const synLists = tokens.map(t => expandSynonyms(t, maxSyn));
-  if (keywords.length) synLists.push(keywords.map(k => k.toLowerCase()));
-
-  const labelMap = new Map<string, Set<string>>();
-  function addLabels(lists: string[][], joiner: string, types: string[]) {
-    for (const l of combine(lists, joiner)) {
-      if (!labelMap.has(l)) labelMap.set(l, new Set());
-      const set = labelMap.get(l)!;
-      types.forEach(t => set.add(t));
-    }
-  }
-
-  const perms = permute(synLists);
-  perms.forEach((lists, idx) => {
-    const baseTypes = idx === 0 ? ['base'] : ['permutation'];
-    addLabels(lists, '', baseTypes);
-    if (lists.length > 1) addLabels(lists, '-', [...baseTypes, 'hyphenated']);
-  });
-
-  if (synLists.length > 1) {
-    const alphaTokens = [...tokens].sort();
-    const alphaLists = alphaTokens.map(t => expandSynonyms(t, maxSyn));
-    addLabels(alphaLists, '', ['alphabetical']);
-  }
-
-  // prefixes and suffixes
-  const prefixes = config.prefixes || [];
-  const suffixes = config.suffixes || [];
-  const withAffixes = new Map<string, Set<string>>();
-
-  labelMap.forEach((types, label) => {
-    const baseSet = withAffixes.get(label) || new Set<string>(types);
-    withAffixes.set(label, baseSet);
-    for (const pre of prefixes) {
-      const l = pre + label;
-      const set = withAffixes.get(l) || new Set<string>(types);
-      set.add('prefix');
-      withAffixes.set(l, set);
-    }
-    for (const suf of suffixes) {
-      const l = label + suf;
-      const set = withAffixes.get(l) || new Set<string>(types);
-      set.add('suffix');
-      withAffixes.set(l, set);
-    }
-  });
-
-  // TLD hacks
-  const finalMap = new Map<string, Set<string>>();
-  withAffixes.forEach((types, label) => {
-    finalMap.set(label, new Set(types));
-    if (!label.includes('.')) {
-      for (const tld of tlds) {
-        if (label.toLowerCase().endsWith(tld.toLowerCase())) {
-          const hacked = label.slice(0, -tld.length) + '.' + tld;
-          const set = finalMap.get(hacked) || new Set<string>(types);
-          set.add('tldHack');
-          finalMap.set(hacked, set);
-        }
-      }
-    }
-  });
-
-  return Array.from(finalMap.entries()).map(([label, types]) => ({
-    label,
-    types: unique(Array.from(types)),
-  }));
+  return combined;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import { DomainSearchParams, DomainResult, SearchResponse, DomainSearchConfig } from './types';
-import { normalizeTokens, unique, isValidTld, getCcTld, normalizeTld } from './utils';
-import { generateLabels } from './generator';
+import { DomainSearchOptions, DomainCandidate, SearchResponse, ClientInitOptions } from './types';
+import { isValidTld, getCcTld, normalizeTld } from './utils';
+import { generateCandidates } from './generator';
 import { scoreDomain } from './ranking';
 import tlds from "./tlds.json" assert { type: "json" };
 
@@ -11,7 +11,7 @@ const TLD_MAP: Record<string, string | boolean> = {
   ...(tlds as any).SLDs,
 };
 
-const DEFAULT_CONFIG: DomainSearchConfig = {
+const DEFAULT_INIT_OPTIONS: Required<ClientInitOptions> = {
   defaultTlds: ['com', 'ng'],
   supportedTlds: Object.keys(TLD_MAP),
   limit: 20,
@@ -50,82 +50,61 @@ function error(message: string): SearchResponse {
 }
 
 export class DomainSearchClient {
-  private config: DomainSearchConfig;
+  private init: Required<ClientInitOptions>;
 
-  constructor(config: Partial<DomainSearchConfig> = {}) {
-    this.config = { ...DEFAULT_CONFIG, ...config };
+  constructor(initOptions: ClientInitOptions = {}) {
+    this.init = { ...DEFAULT_INIT_OPTIONS, ...initOptions };
   }
 
-  setConfig(config: Partial<DomainSearchConfig>): void {
-    this.config = { ...this.config, ...config };
+  setInitOptions(options: ClientInitOptions): void {
+    this.init = { ...this.init, ...options };
   }
 
-  getConfig(): DomainSearchConfig {
-    return this.config;
+  getInitOptions(): Required<ClientInitOptions> {
+    return this.init;
   }
 
-  async search(params: DomainSearchParams): Promise<SearchResponse> {
+  async search(options: DomainSearchOptions): Promise<SearchResponse> {
     const start = Date.now();
-    if (!params.query || !params.query.trim()) return error('query is required');
+    if (!options.query || !options.query.trim()) return error('query is required');
 
-    const limit = params.limit ?? this.config.limit;
+    const cfg = { ...this.init, ...options };
+    const limit = cfg.limit ?? this.init.limit;
     if (!Number.isFinite(limit) || limit <= 0) return error('limit must be positive');
 
-    if (params.keywords && !Array.isArray(params.keywords)) return error('keywords must be an array');
-    if (params.supportedTlds && !Array.isArray(params.supportedTlds)) return error('supportedTlds must be an array');
-    if (params.defaultTlds && !Array.isArray(params.defaultTlds)) return error('defaultTlds must be an array');
+    if (options.keywords && !Array.isArray(options.keywords)) return error('keywords must be an array');
+    if (options.supportedTlds && !Array.isArray(options.supportedTlds)) return error('supportedTlds must be an array');
+    if (options.defaultTlds && !Array.isArray(options.defaultTlds)) return error('defaultTlds must be an array');
 
-    const supportedTlds = (params.supportedTlds ?? this.config.supportedTlds).map(normalizeTld);
-    const defaultTlds = (params.defaultTlds ?? this.config.defaultTlds).map(normalizeTld);
+    const supportedTlds = (cfg.supportedTlds || []).map(normalizeTld);
+    const defaultTlds = (cfg.defaultTlds || []).map(normalizeTld);
     for (const t of [...supportedTlds, ...defaultTlds]) {
       if (!isValidTld(t)) return error(`invalid tld: ${t}`);
     }
 
-    const tokens = normalizeTokens(params.query);
-    const keywords = params.keywords?.map(k => k.toLowerCase()) || [];
-    const tldsForGen = unique([...supportedTlds, ...defaultTlds]);
-    const labels = generateLabels(tokens, keywords, tldsForGen, {
-      prefixes: this.config.prefixes,
-      suffixes: this.config.suffixes,
-      maxSynonyms: this.config.maxSynonyms,
-    });
-
-    let tlds = tldsForGen.slice();
-    const cc = getCcTld(params.location);
-    if (cc && !tlds.includes(cc)) tlds.push(cc);
+    const cc = getCcTld(options.location);
     if (cc && !supportedTlds.includes(cc)) supportedTlds.push(cc);
+    if (cc && !defaultTlds.includes(cc)) defaultTlds.push(cc);
 
-    const results: DomainResult[] = [];
-    for (const { label, types } of labels) {
-      if (label.length === 0) continue;
-      if (label.includes('.')) {
-        const parts = label.split('.');
-        const suffix = parts.pop() || '';
-        if (supportedTlds.includes(suffix)) {
-          const domain = label;
-          const score = scoreDomain(parts.join('.'), suffix, cc, {
-            tldWeights: this.config.tldWeights,
-          });
-          results.push({ domain, suffix, score, isAvailable: false, variantTypes: types });
-        }
-        continue;
-      }
-      for (const tld of tlds) {
-        if (supportedTlds && !supportedTlds.includes(tld)) continue;
-        const domain = `${label}.${tld}`;
-        const score = scoreDomain(label, tld, cc, { tldWeights: this.config.tldWeights });
-        results.push({ domain, suffix: tld, score, isAvailable: false, variantTypes: types });
-      }
+    cfg.supportedTlds = supportedTlds;
+    cfg.defaultTlds = defaultTlds;
+
+    const candidates = await generateCandidates(cfg);
+
+    const results: DomainCandidate[] = [];
+    for (const cand of candidates) {
+      if (!cand.domain || !cand.suffix) continue;
+      if (!supportedTlds.includes(cand.suffix)) continue;
+      const label = cand.domain.slice(0, -(cand.suffix.length + 1));
+      const score = scoreDomain(label, cand.suffix, cc, { tldWeights: cfg.tldWeights });
+      results.push({ domain: cand.domain, suffix: cand.suffix, strategy: cand.strategy, score, isAvailable: false });
     }
 
-    const resultMap = new Map<string, DomainResult>();
+    const resultMap = new Map<string, DomainCandidate>();
     for (const r of results) {
       const existing = resultMap.get(r.domain);
       if (existing) {
         if (r.score > existing.score) existing.score = r.score;
-        if (r.variantTypes) {
-          existing.variantTypes = unique([...(existing.variantTypes || []), ...r.variantTypes]);
-        }
       } else {
         resultMap.set(r.domain, { ...r });
       }
@@ -134,23 +113,36 @@ export class DomainSearchClient {
     uniqueResults.sort((a, b) => b.score - a.score);
 
     let finalResults = uniqueResults.slice(0, limit);
-    if (!params.debug) {
-      finalResults = finalResults.map(r => ({ domain: r.domain, suffix: r.suffix, score: r.score }));
+    if (!options.debug) {
+      finalResults = finalResults.map(r => ({ domain: r.domain, suffix: r.suffix, score: r.score, strategy: r.strategy }));
     }
 
     const end = Date.now();
     return {
       results: finalResults,
       success: true,
-      includesAiGenerations: !!params.useAi,
+      includesAiGenerations: !!options.useAi,
       metadata: {
         searchTime: end - start,
         totalGenerated: uniqueResults.length,
-        filterApplied: !!params.supportedTlds,
+        filterApplied: !!options.supportedTlds,
       },
     };
   }
 }
 
-export type { DomainSearchParams, DomainResult, SearchResponse } from './types';
-export { generateLabels } from './generator';
+export type {
+  DomainSearchOptions,
+  ClientInitOptions,
+  DomainCandidate,
+  SearchResponse,
+  SearchMetadata,
+  GenerationStrategy,
+} from './types';
+export { generateCandidates } from './generator';
+export {
+  PermutationStrategy,
+  AlphabeticalStrategy,
+  AffixStrategy,
+  TldHackStrategy,
+} from './strategies';

--- a/src/strategies/affix.ts
+++ b/src/strategies/affix.ts
@@ -1,0 +1,44 @@
+/**
+ * Generates domain variants by applying prefixes and suffixes to token combinations.
+*/
+import { expandSynonyms } from '../synonyms';
+import { combine, normalizeTokens } from '../utils';
+import { DomainSearchOptions, DomainCandidate, GenerationStrategy } from '../types';
+
+export class AffixStrategy implements GenerationStrategy {
+  async generate(opts: DomainSearchOptions): Promise<Partial<DomainCandidate>[]> {
+    const prefixes = opts.prefixes ?? [];
+    const suffixes = opts.suffixes ?? [];
+    const tlds = Array.from(new Set([...(opts.supportedTlds || []), ...(opts.defaultTlds || [])]));
+    if ((!prefixes.length && !suffixes.length) || !tlds.length) return [];
+
+    const tokens = normalizeTokens(opts.query);
+    const keywords = (opts.keywords || []).map(k => k.toLowerCase());
+    const maxSynonyms = opts.maxSynonyms ?? 5;
+    const synLists = tokens.map(t => expandSynonyms(t, maxSynonyms));
+    if (keywords.length) synLists.push(keywords);
+    const bases = combine(synLists, '');
+
+    const results: Partial<DomainCandidate>[] = [];
+    for (const base of bases) {
+      if (prefixes.length) {
+        for (const pre of prefixes) {
+          const label = pre + base;
+          for (const tld of tlds) {
+            results.push({ domain: `${label}.${tld}`, suffix: tld });
+          }
+        }
+      }
+      if (suffixes.length) {
+        for (const suf of suffixes) {
+          const label = base + suf;
+          for (const tld of tlds) {
+            results.push({ domain: `${label}.${tld}`, suffix: tld });
+          }
+        }
+      }
+    }
+
+    return results;
+  }
+}

--- a/src/strategies/alphabetical.ts
+++ b/src/strategies/alphabetical.ts
@@ -1,0 +1,26 @@
+/**
+ * Generates alphabetical domain combinations from tokens using synonyms.
+*/
+import { expandSynonyms } from '../synonyms';
+import { unique, normalizeTokens, combine } from '../utils';
+import { DomainSearchOptions, DomainCandidate, GenerationStrategy } from '../types';
+
+export class AlphabeticalStrategy implements GenerationStrategy {
+  async generate(opts: DomainSearchOptions): Promise<Partial<DomainCandidate>[]> {
+    const tokens = normalizeTokens(opts.query);
+    if (tokens.length < 2) return [];
+    const maxSynonyms = opts.maxSynonyms ?? 5;
+    const alphaTokens = [...tokens].sort();
+    const alphaLists = alphaTokens.map(t => expandSynonyms(t, maxSynonyms));
+    const labels = unique(combine(alphaLists, ''));
+    const tlds = Array.from(new Set([...(opts.supportedTlds || []), ...(opts.defaultTlds || [])]));
+    if (!tlds.length) return [];
+    const results: Partial<DomainCandidate>[] = [];
+    for (const label of labels) {
+      for (const tld of tlds) {
+        results.push({ domain: `${label}.${tld}`, suffix: tld });
+      }
+    }
+    return results;
+  }
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -1,0 +1,4 @@
+export * from './permutation';
+export * from './alphabetical';
+export * from './affix';
+export * from './tldHack';

--- a/src/strategies/permutation.ts
+++ b/src/strategies/permutation.ts
@@ -1,0 +1,50 @@
+/**
+ * Generates domain permutations and optional hyphenated combinations from tokens and keywords.
+*/
+import { expandSynonyms } from '../synonyms';
+import { normalizeTokens, combine, permute } from '../utils';
+import { DomainSearchOptions, DomainCandidate, GenerationStrategy } from '../types';
+
+export interface PermutationStrategyOptions {
+  includeHyphenated?: boolean;
+}
+
+export class PermutationStrategy implements GenerationStrategy {
+  private opts: Required<PermutationStrategyOptions>;
+
+  constructor(opts: PermutationStrategyOptions = {}) {
+    this.opts = { includeHyphenated: true, ...opts };
+  }
+
+  async generate(opts: DomainSearchOptions): Promise<Partial<DomainCandidate>[]> {
+    const tokens = normalizeTokens(opts.query);
+    const keywords = (opts.keywords || []).map(k => k.toLowerCase());
+    const maxSynonyms = opts.maxSynonyms ?? 5;
+    const synLists = tokens.map(t => expandSynonyms(t, maxSynonyms));
+    if (keywords.length) synLists.push(keywords);
+    const perms = permute(synLists);
+
+    const labels = new Set<string>();
+    perms.forEach(lists => {
+      for (const l of combine(lists, '')) labels.add(l);
+      if (this.opts.includeHyphenated && lists.length > 1) {
+        for (const l of combine(lists, '-')) labels.add(l);
+      }
+    });
+
+    const tlds = Array.from(new Set([...(opts.supportedTlds || []), ...(opts.defaultTlds || [])]));
+    if (!tlds.length) return [];
+
+    const map = new Map<string, Partial<DomainCandidate>>();
+    labels.forEach(label => {
+      for (const tld of tlds) {
+        const domain = `${label}.${tld}`;
+        if (!map.has(domain)) {
+          map.set(domain, { domain, suffix: tld });
+        }
+      }
+    });
+
+    return Array.from(map.values());
+  }
+}

--- a/src/strategies/tldHack.ts
+++ b/src/strategies/tldHack.ts
@@ -1,0 +1,36 @@
+/**
+ * Generates domain hacks by inserting dots before matching TLD endings.
+*/
+import { expandSynonyms } from '../synonyms';
+import { combine, normalizeTokens } from '../utils';
+import { DomainSearchOptions, DomainCandidate, GenerationStrategy } from '../types';
+
+export class TldHackStrategy implements GenerationStrategy {
+  async generate(opts: DomainSearchOptions): Promise<Partial<DomainCandidate>[]> {
+    const tlds = Array.from(new Set([...(opts.supportedTlds || []), ...(opts.defaultTlds || [])])).map(t => t.toLowerCase());
+    if (!tlds.length) return [];
+    const tokens = normalizeTokens(opts.query);
+    const keywords = (opts.keywords || []).map(k => k.toLowerCase());
+    const maxSynonyms = opts.maxSynonyms ?? 5;
+    const synLists = tokens.map(t => expandSynonyms(t, maxSynonyms));
+    if (keywords.length) synLists.push(keywords);
+    const bases = combine(synLists, '');
+    const results: Partial<DomainCandidate>[] = [];
+    for (const label of bases) {
+      if (label.includes('.')) continue;
+      for (const tld of tlds) {
+        if (label.toLowerCase().endsWith(tld)) {
+          const domain = label.slice(0, -tld.length) + '.' + tld;
+          results.push({ domain, suffix: tld });
+        }
+      }
+    }
+    const seen = new Set<string>();
+    return results.filter(r => {
+      if (!r.domain) return false;
+      if (seen.has(r.domain)) return false;
+      seen.add(r.domain);
+      return true;
+    });
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,41 +1,58 @@
-export interface DomainSearchParams {
+// Options --------------------------------------------------------------------
+
+/** Configuration provided when initializing the client. */
+export interface ClientInitOptions {
+  defaultTlds?: string[];
+  supportedTlds?: string[];
+  limit?: number;
+  prefixes?: string[];
+  suffixes?: string[];
+  maxSynonyms?: number;
+  tldWeights?: Record<string, number>;
+}
+
+/** Per-search options extending the client defaults. */
+export interface DomainSearchOptions extends ClientInitOptions {
   query: string;
   keywords?: string[];
   location?: string;
-  supportedTlds?: string[];
-  defaultTlds?: string[];
-  limit?: number;
   debug?: boolean;
   useAi?: boolean;
 }
 
-export interface DomainResult {
+// Results --------------------------------------------------------------------
+
+/** Represents a generated domain name candidate. */
+export interface DomainCandidate {
   domain: string;
   suffix: string;
   score: number;
   isAvailable?: boolean;
   aiGenerated?: boolean;
   variantTypes?: string[];
+  strategy?: string;
 }
 
+/** Metadata describing a search operation. */
+export interface SearchMetadata {
+  searchTime: number;
+  totalGenerated: number;
+  filterApplied: boolean;
+}
+
+/** Response returned from a domain search. */
 export interface SearchResponse {
-  results: DomainResult[];
+  results: DomainCandidate[];
   success: boolean;
   message?: string;
   includesAiGenerations: boolean;
-  metadata: {
-    searchTime: number;
-    totalGenerated: number;
-    filterApplied: boolean;
-  };
+  metadata: SearchMetadata;
 }
 
-export interface DomainSearchConfig {
-  defaultTlds: string[];
-  supportedTlds: string[];
-  limit: number;
-  prefixes?: string[];
-  suffixes?: string[];
-  maxSynonyms?: number;
-  tldWeights?: Record<string, number>;
+// Strategies -----------------------------------------------------------------
+
+/** Contract implemented by all generation strategies. */
+export interface GenerationStrategy {
+  generate(opts: DomainSearchOptions): Promise<Partial<DomainCandidate>[]>;
 }
+

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,22 +10,37 @@ const LOCATION_MAP: Record<string, string> = {
   'ng': 'ng',
 };
 
+/**
+ * Breaks an input string into lowercase alphanumeric tokens.
+ */
 export function normalizeTokens(input: string): string[] {
   return (input.toLowerCase().match(/[a-z0-9]+/g) || []);
 }
 
+/**
+ * Normalizes a TLD by removing any leading dot and lowercasing.
+ */
 export function normalizeTld(tld: string): string {
   return tld.replace(/^\./, '').toLowerCase();
 }
 
+/**
+ * Checks if a TLD string is syntactically valid.
+ */
 export function isValidTld(tld: string): boolean {
   return TLD_REGEX.test(normalizeTld(tld));
 }
 
+/**
+ * Returns a deduplicated array preserving original order.
+ */
 export function unique<T>(arr: T[]): T[] {
   return Array.from(new Set(arr));
 }
 
+/**
+ * Maps a location string to a country-code TLD, if known.
+ */
 export function getCcTld(location?: string): string | undefined {
   if (!location) return undefined;
   const lower = location.toLowerCase();
@@ -36,13 +51,54 @@ export function getCcTld(location?: string): string | undefined {
   return undefined;
 }
 
+/**
+ * Determines if the given string contains any numeric characters.
+ */
 export function containsNumber(str: string): boolean {
   return /\d/.test(str);
 }
 
+/**
+ * Calculates the ratio of vowels to total alphabetic characters in a string.
+ */
 export function vowelRatio(str: string): number {
   const letters = str.replace(/[^a-z]/gi, '');
   if (letters.length === 0) return 0;
   const vowels = letters.match(/[aeiou]/gi)?.length || 0;
   return vowels / letters.length;
+}
+
+/**
+ * Produces all combinations by choosing one element from each list and joining
+ * them with an optional separator.
+ */
+export function combine(lists: string[][], joiner = ''): string[] {
+  const results: string[] = [];
+  function helper(prefix: string, idx: number) {
+    if (idx === lists.length) {
+      results.push(prefix);
+      return;
+    }
+    for (const token of lists[idx]) {
+      const next = prefix ? prefix + joiner + token : token;
+      helper(next, idx + 1);
+    }
+  }
+  if (lists.length) helper('', 0);
+  return results;
+}
+
+/**
+ * Generates every permutation of the provided array.
+ */
+export function permute<T>(arr: T[]): T[][] {
+  if (arr.length <= 1) return [arr];
+  const result: T[][] = [];
+  arr.forEach((item, idx) => {
+    const rest = [...arr.slice(0, idx), ...arr.slice(idx + 1)];
+    for (const p of permute(rest)) {
+      result.push([item, ...p]);
+    }
+  });
+  return result;
 }

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -1,24 +1,37 @@
 import test from 'ava';
-import { generateLabels } from '../dist/index.js';
+import { generateCandidates } from '../dist/index.js';
 
-const find = (labels, label) => labels.find(l => l.label === label);
-
-test('generator produces permutations, hyphenated and affix variants', t => {
-  const labels = generateLabels(['fast', 'tech'], [], [], {
+test('generator produces permutations, hyphenated and affix variants', async t => {
+  const candidates = await generateCandidates({
+    query: 'fast tech',
     prefixes: ['pre'],
     suffixes: ['suf'],
+    supportedTlds: ['com'],
+    defaultTlds: [],
+    maxSynonyms: 1,
   });
-  t.true(find(labels, 'fasttech').types.includes('base'));
-  t.true(find(labels, 'techfast').types.includes('permutation'));
-  t.true(find(labels, 'fast-tech').types.includes('hyphenated'));
-  t.true(find(labels, 'prefasttech').types.includes('prefix'));
-  t.true(find(labels, 'fasttechsuf').types.includes('suffix'));
+  const domains = candidates.map(c => c.domain);
+  t.true(domains.includes('fasttech.com'));
+  t.true(domains.includes('techfast.com'));
+  t.true(domains.includes('fast-tech.com'));
+  t.true(domains.includes('prefasttech.com'));
+  t.true(domains.includes('fasttechsuf.com'));
 });
 
-test('generator produces alphabetical and tldHack variants', t => {
-  const alphaLabels = generateLabels(['z', 'a']);
-  t.true(find(alphaLabels, 'az').types.includes('alphabetical'));
+test('generator produces alphabetical and tldHack variants', async t => {
+  const alpha = await generateCandidates({
+    query: 'z a',
+    supportedTlds: ['com'],
+    defaultTlds: [],
+    maxSynonyms: 1,
+  });
+  t.true(alpha.some(c => c.domain === 'az.com'));
 
-  const hackLabels = generateLabels(['brandly'], [], ['ly']);
-  t.true(find(hackLabels, 'brand.ly').types.includes('tldHack'));
+  const hack = await generateCandidates({
+    query: 'brandly',
+    supportedTlds: ['ly'],
+    defaultTlds: [],
+    maxSynonyms: 1,
+  });
+  t.true(hack.some(c => c.domain === 'brand.ly'));
 });

--- a/test/strategies/affix.test.js
+++ b/test/strategies/affix.test.js
@@ -1,0 +1,26 @@
+import test from 'ava';
+import { AffixStrategy } from '../../dist/index.js';
+
+const base = {
+  prefixes: ['pre'],
+  suffixes: ['suf'],
+  supportedTlds: ['com'],
+  defaultTlds: [],
+  maxSynonyms: 1,
+};
+
+test('affix strategy handles single-word query', async t => {
+  const strategy = new AffixStrategy();
+  const res = await strategy.generate({ ...base, query: 'fast' });
+  const domains = res.map(r => r.domain);
+  t.true(domains.includes('prefast.com'));
+  t.true(domains.includes('fastsuf.com'));
+});
+
+test('affix strategy handles multi-word query', async t => {
+  const strategy = new AffixStrategy();
+  const res = await strategy.generate({ ...base, query: 'fast tech' });
+  const domains = res.map(r => r.domain);
+  t.true(domains.includes('prefasttech.com'));
+  t.true(domains.includes('fasttechsuf.com'));
+});

--- a/test/strategies/alphabetical.test.js
+++ b/test/strategies/alphabetical.test.js
@@ -1,0 +1,21 @@
+import test from 'ava';
+import { AlphabeticalStrategy } from '../../dist/index.js';
+
+const opts = {
+  query: 'z a',
+  supportedTlds: ['com'],
+  defaultTlds: [],
+  maxSynonyms: 1,
+};
+
+test('alphabetical strategy handles multi-word query', async t => {
+  const strategy = new AlphabeticalStrategy();
+  const res = await strategy.generate(opts);
+  t.deepEqual(res.map(r => r.domain), ['az.com']);
+});
+
+test('alphabetical strategy returns empty for single-word query', async t => {
+  const strategy = new AlphabeticalStrategy();
+  const res = await strategy.generate({ ...opts, query: 'solo' });
+  t.is(res.length, 0);
+});

--- a/test/strategies/permutation.test.js
+++ b/test/strategies/permutation.test.js
@@ -1,0 +1,24 @@
+import test from 'ava';
+import { PermutationStrategy } from '../../dist/index.js';
+
+const opts = {
+  query: 'fast tech',
+  supportedTlds: ['com'],
+  defaultTlds: [],
+  maxSynonyms: 1,
+};
+
+test('permutation strategy handles multi-word query', async t => {
+  const strategy = new PermutationStrategy();
+  const results = await strategy.generate(opts);
+  const domains = results.map(r => r.domain);
+  t.true(domains.includes('fasttech.com'));
+  t.true(domains.includes('techfast.com'));
+  t.true(domains.includes('fast-tech.com'));
+});
+
+test('permutation strategy handles single-word query', async t => {
+  const strategy = new PermutationStrategy();
+  const res = await strategy.generate({ ...opts, query: 'solo' });
+  t.deepEqual(res.map(r => r.domain), ['solo.com']);
+});

--- a/test/strategies/tldHack.test.js
+++ b/test/strategies/tldHack.test.js
@@ -1,0 +1,26 @@
+import test from 'ava';
+import { TldHackStrategy } from '../../dist/index.js';
+
+const base = {
+  supportedTlds: ['ly'],
+  defaultTlds: [],
+  maxSynonyms: 1,
+};
+
+test('tld hack strategy handles single-word query', async t => {
+  const strategy = new TldHackStrategy();
+  const res = await strategy.generate({ ...base, query: 'brandly' });
+  t.deepEqual(res.map(r => r.domain), ['brand.ly']);
+});
+
+test('tld hack strategy handles multi-word query', async t => {
+  const strategy = new TldHackStrategy();
+  const res = await strategy.generate({ ...base, query: 'brand ly' });
+  t.deepEqual(res.map(r => r.domain), ['brand.ly']);
+});
+
+test('tld hack strategy returns empty when no match', async t => {
+  const strategy = new TldHackStrategy();
+  const res = await strategy.generate({ ...base, query: 'hello world' });
+  t.deepEqual(res, []);
+});


### PR DESCRIPTION
## Summary
- remove redundant strategy-specific options in favor of global search options
- consolidate strategy helpers into shared utils with documentation
- centralize generation interfaces and expand tests for single- and multi-word queries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b85e3a44ec8326a06f92d2d6fd9a74